### PR TITLE
Make Translation Context optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.1.1 (patch release)
 
-- translation context made optional.
+- translation context made optional
 
 
 # v0.1.0 (minor release)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.1.1 (patch release)
+
+- translation context made optional.
+
 
 # v0.1.0 (minor release)
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ middleware:
 | -------------- | ------------------------------------------------------------ |--------------------------------------------------------------------|
 | fluent         | Fluent                                                       | An instance of [Fluent][moebius-fluent].                           |
 | translator     | Translator                                                   | An instance of [Translator][moebius-fluent].                                       |
-| translate \| t | (**messageId**: string, **context**: TranslationContext) => string | Translation function bound to the automatically detected user locale. Shorthand alias "t" is also available. |
+| translate \| t | (**messageId**: string, **context?**: TranslationContext) => string | Translation function bound to the automatically detected user locale. Shorthand alias "t" is also available. |
 
 Make sure to use `FluentContextFlavor` to extend your
 application context in order for typings to work correctly:

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ session by the i18n plugin.
 ## Contributors
 
 - [Slava Fomin II](https://github.com/slavafomin) (author)
-
+- [dcdunkan](https://github.com/dcdunkan)
 
 ## License (MIT)
 

--- a/package.json
+++ b/package.json
@@ -38,7 +38,13 @@
     "email": "slava@fomin.io",
     "url": "https://github.com/slavafomin"
   },
-  "contributors": [],
+  "contributors": [
+    {
+      "name": "dcdunkan",
+      "email": "dcdunkan@gmail.com",
+      "url": "http://github.com/dcdunkan"
+    }
+  ],
   "engines": {
     "node": ">=12"
   },
@@ -60,3 +66,4 @@
     "typescript": "^4.5.4"
   }
 }
+

--- a/src/context.ts
+++ b/src/context.ts
@@ -7,7 +7,7 @@ export interface FluentContextFlavor {
   fluent: Fluent;
   translator: Translator;
   translate: (messageId: string, context: TranslationContext) => string;
-  t: (messageId: string, context: TranslationContext) => string;
+  t: (messageId: string, context?: TranslationContext) => string;
 }
 
 

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,7 +6,7 @@ import { Context } from 'grammy';
 export interface FluentContextFlavor {
   fluent: Fluent;
   translator: Translator;
-  translate: (messageId: string, context: TranslationContext) => string;
+  translate: (messageId: string, context?: TranslationContext) => string;
   t: (messageId: string, context?: TranslationContext) => string;
 }
 


### PR DESCRIPTION
I don't think every message need variables. Added support for messages like that.

```fluent
# Message with context.
start =
  Welcome, {$name}

# Message without context.
help =
  Hi there! I can help you :)
```

```ts
bot.command("start", async (ctx) => {
  await ctx.reply(
    ctx.t("start", {
      name: ctx.from.first_name,
    })
  );
});

// If context wasn't optional, TS will throw,
// "Expected 2 arguments, but got 1. An argument for 'context' was not provided."
bot.command("help", async (ctx) => await ctx.reply(ctx.t("help")));
```

