### PR TITLE
localeNegotiator with custom context

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fluent localization system integration for grammY Telegram bot framework",
   "scripts": {
     "build": "rm -rf ./dist && tsc -p ./tsconfig.lib.json",
-    "prepublishOnly": "npm run build",
+    "prepack": "npm run build",
     "test": ":"
   },
   "main": "dist/index.js",

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,10 +5,10 @@ import { Context, Middleware, NextFunction } from 'grammy';
 import { defaultLocaleNegotiator, LocaleNegotiator } from './locale-negotiator';
 
 
-export interface GrammyFluentOptions {
+export interface GrammyFluentOptions<ContextType extends Context = Context> {
   fluent: Fluent;
   defaultLocale?: LocaleId;
-  localeNegotiator?: LocaleNegotiator;
+  localeNegotiator?: LocaleNegotiator<ContextType>;
 }
 
 export type TranslateFunction = (
@@ -29,10 +29,10 @@ export interface FluentContextFlavor {
 const fallbackLocale = 'en';
 
 
-export function useFluent(
-  options: GrammyFluentOptions
+export function useFluent<ContextType extends Context = Context>(
+  options: GrammyFluentOptions<ContextType>
 
-): Middleware {
+): Middleware<ContextType> {
 
   const {
     fluent,
@@ -47,7 +47,7 @@ export function useFluent(
    * to the context object.
    */
   return async function fluentMiddleware(
-    context: Context,
+    context: ContextType,
     next: NextFunction
 
   ): Promise<void> {


### PR DESCRIPTION
Using the localeNegotiator doesnt work with a custom context currently.
This is needed to access things like ctx.session (like the examples in the README are suggesting).

There does not seem to be a code formatting specified, it differs inside the files and no npm script for it. Maybe use `deno fmt` in the future?

I test changes with `npm pack` and install the created package in another project. PrepublishOnly does not work for npm pack. prepack does also work for publishing a package.